### PR TITLE
team_join test and fixed team_join handling

### DIFF
--- a/bot/slack.py
+++ b/bot/slack.py
@@ -234,7 +234,7 @@ def parse_next_msg():
     if event_type == "team_join":
         # return the message to apply the karma change
         # https://api.slack.com/methods/users.info
-        welcome_msg = AUTOMATED_COMMANDS["welcome"](user_id)  # new user joining
+        welcome_msg = AUTOMATED_COMMANDS["welcome"](user_id["id"])  # new user joining
         post_msg(user_id["id"], welcome_msg)
         # return Message object to handle karma in main
         return Message(


### PR DESCRIPTION
1. `test_slack_team_join` provides testing for team_events by mocking` SLACK_CLIENT.rtm_read()`

2. Fixed the `user_id` / `user_id["id"]` confusion which is different for plain messages and some events (e.g. `team_join`) 