### PR TITLE
Fix seconds since last post for topchannels

### DIFF
--- a/commands/topchannels.py
+++ b/commands/topchannels.py
@@ -106,7 +106,7 @@ def calc_channel_score(channel: Channel):
 def seconds_since_last_post(channel: Channel) -> float:
     """return the fraction of days since the last post in a channel
     """
-    return (dt.now() - dt.fromtimestamp(channel.latest_ts)).seconds
+    return (dt.now() - dt.fromtimestamp(channel.latest_ts)).total_seconds()
 
 
 if __name__ == "__main__":

--- a/tests/slack_testdata.py
+++ b/tests/slack_testdata.py
@@ -116,5 +116,40 @@ TEST_CHANNEL_INFO = {
             },
             "previous_names": ["dusting"],
         },
+    },
+    "CHANNEL43": {
+        "ok": True,
+        "channel": {
+            "id": "CHANNEL43",
+            "name": "Slightly Less Awesome Test Channel",
+            "is_channel": True,
+            "created": 1466025154,
+            "creator": "ABC123",
+            "name_normalized": "Slightly Less Awesome Test Channel",
+            "last_read": "1503435939.000101",
+            "latest": {
+                "text": "Hamsters are small but fast",
+                "username": "karmabot",
+                "bot_id": KARMABOT_ID,
+                "attachments": [],
+                "type": "message",
+                "subtype": "bot_message",
+                "ts": "1503353156.000247",
+            },
+            "unread_count": 1,
+            "unread_count_display": 1,
+            "members": ["ABC123", "EFG123"],
+            "topic": {
+                "value": "Having less active discussions",
+                "creator": "ABC123",
+                "last_set": 1503435128,
+            },
+            "purpose": {
+                "value": "Do things and talk about stuff",
+                "creator": "ABC123",
+                "last_set": 1503435128,
+            },
+            "previous_names": ["pancakes"],
+        }
     }
 }


### PR DESCRIPTION
Use timedelta's `total_seconds()` method rather than the `seconds`
attribute. This fixes an issue with the "hours since last activity" calculation in `topchannels`.

Most of the code here is test data and patching `datetime.now()`: without a recent `now()` the channel scores are 0. Suggestions/updates welcome regarding clearer ways to handle the testing.