### PR TITLE
Filter out channel join messages for topchannels

### DIFF
--- a/commands/topchannels.py
+++ b/commands/topchannels.py
@@ -21,7 +21,7 @@ TOP_CHANNELS = """Glad you asked, here are some channels our Communtiy recommend
 """
 
 MSG_BEGIN = "Glad you asked, here are some channels our Communtiy recommends (based on member count and activity):\n"
-LIST_ICON = "-"
+MSG_LINE = "- #{channel} ({member_count} members, {hours_since_last_post:.0f} hour(s) since last post): {purpose}"
 DEFAULT_NR_CHANNELS = 7
 
 Channel = namedtuple("Channel", "id name purpose num_members latest_ts latest_subtype")
@@ -94,7 +94,13 @@ def get_recommended_channels(**kwargs):
 
     msg = MSG_BEGIN + "\n".join(
         (
-            f'{LIST_ICON} #{channel.name} ({channel.num_members} members, {seconds_since_last_post(channel) / 3600:.0f} hour(s) since last post): {channel.purpose if channel.purpose else "<Invest today and get an awesome description!>"}'
+            MSG_LINE.format(
+                channel=channel.name,
+                member_count=channel.num_members,
+                hours_since_last_post=seconds_since_last_post(channel) / 3600,
+                purpose=channel.purpose
+                or "<Invest today and get an awesome description!>",
+            )
             for score, channel in potential_channels[:nr_channels]
             if score > 0
         )

--- a/commands/topchannels.py
+++ b/commands/topchannels.py
@@ -1,8 +1,12 @@
 import logging
+import os
 from collections import namedtuple
 from datetime import datetime as dt
 from math import exp
-from typing import List, Dict
+from operator import itemgetter
+from typing import Dict, List, Optional
+
+from slackclient import SlackClient
 
 from bot.settings import SLACK_CLIENT
 
@@ -20,7 +24,7 @@ MSG_BEGIN = "Glad you asked, here are some channels our Communtiy recommends (ba
 LIST_ICON = "-"
 DEFAULT_NR_CHANNELS = 7
 
-Channel = namedtuple("Channel", "id name purpose num_members latest_ts")
+Channel = namedtuple("Channel", "id name purpose num_members latest_ts latest_subtype")
 
 
 def get_recommended_channels(**kwargs):
@@ -79,16 +83,22 @@ def get_recommended_channels(**kwargs):
                         channel_info["purpose"]["value"],
                         channel["num_members"],
                         float(channel_info["latest"]["ts"]),
+                        channel_info["latest"].get("subtype"),
                     )
                 )
 
     # now weight channels and return message
     potential_channels = sorted(
-        potential_channels, key=calc_channel_score, reverse=True
+        ((calc_channel_score(chan), chan) for chan in potential_channels), reverse=True
     )
 
-    for channel in potential_channels[:nr_channels]:
-        msg += f'{LIST_ICON} #{channel.name} ({channel.num_members} members, {seconds_since_last_post(channel) / 3600:.0f} hour(s) since last post): {channel.purpose if channel.purpose else "<Invest today and get an awesome description!>"}\n'
+    msg = MSG_BEGIN + "\n".join(
+        (
+            f'{LIST_ICON} #{channel.name} ({channel.num_members} members, {seconds_since_last_post(channel) / 3600:.0f} hour(s) since last post): {channel.purpose if channel.purpose else "<Invest today and get an awesome description!>"}'
+            for score, channel in potential_channels[:nr_channels]
+            if score > 0
+        )
+    )
 
     return msg
 
@@ -97,16 +107,54 @@ def calc_channel_score(channel: Channel):
     """simple calculation of a channels value
     the higher the number of members and the less the number of seconds since the last post the higher the channels score
     """
+    since_latest = seconds_since_last_post(channel)
+    if not since_latest:
+        return 0
     num_members = channel.num_members
-    time_delta_in_hours = seconds_since_last_post(channel) / 3600
+    time_delta_in_hours = since_latest / 3600
 
     return num_members * (exp(-time_delta_in_hours))
 
 
-def seconds_since_last_post(channel: Channel) -> float:
-    """return the fraction of days since the last post in a channel
+def seconds_since_last_post(channel: Channel) -> Optional[float]:
+    """return the fraction of days since the last post in a channel, or None if
+    all messages are of filtered/ignored subtypes
     """
-    return (dt.now() - dt.fromtimestamp(channel.latest_ts)).total_seconds()
+    ignore_message_types = {"channel_join"}
+
+    if channel.latest_subtype not in ignore_message_types:
+        latest_ts = channel.latest_ts
+    else:
+        # The latest message in this channel has an ignored subtype, so we need
+        # to dig through history to find the most recent non-ignored message.
+        # Similar to invite permissions, this requires a user token.
+        #
+        # "New" bot tokens will be both more granular and more flexible, so should
+        # be able to replace the need for user tokens going forward:
+        #
+        # Ref: https://api.slack.com/docs/token-types#bot_new
+
+        grant_user_token = os.environ.get("SLACK_KARMA_INVITE_USER_TOKEN")
+        karmabot_id = os.environ.get("SLACK_KARMA_BOTUSER")
+        if not grant_user_token:
+            logging.info(
+                "Cannot search channel history, no env SLACK_KARMA_INVITE_USER_TOKEN"
+            )
+            return None
+
+        sc = SlackClient(grant_user_token)
+        response = sc.api_call("channels.history", channel=channel.id, user=karmabot_id)
+
+        msgs = [
+            msg
+            for msg in response["messages"]
+            if msg.get("subtype") not in ignore_message_types
+        ]
+        if not msgs:
+            return None
+        latest_ts = float(max(msgs, key=itemgetter("ts"))["ts"])
+
+    return (dt.now() - dt.fromtimestamp(latest_ts)).total_seconds()
 
 
 if __name__ == "__main__":

--- a/tests/slack_testdata.py
+++ b/tests/slack_testdata.py
@@ -150,6 +150,118 @@ TEST_CHANNEL_INFO = {
                 "last_set": 1503435128,
             },
             "previous_names": ["pancakes"],
-        }
-    }
+        },
+    },
+    "SOMEJOINS": {
+        "ok": True,
+        "channel": {
+            "id": "SOMEJOINS",
+            "name": "Some joiny bits with a dash of chatter",
+            "is_channel": True,
+            "created": 1466025154,
+            "creator": "ABC123",
+            "name_normalized": "Some joiny bits with a dash of chatter",
+            "last_read": "1503435939.000101",
+            "latest": {
+                "type": "message",
+                "subtype": "channel_join",
+                "ts": "1503353156.000247",
+                "user": "URVU20YHL",
+                "text": "<@URVU20YHL> has joined the channel",
+            },
+            "members": ["ABC123", "EFG123"],
+            "purpose": {
+                "value": "Drink milk loudly through a straw",
+                "creator": "ABC123",
+                "last_set": 1503435128,
+            },
+        },
+    },
+    "ONLYJOINS": {
+        "ok": True,
+        "channel": {
+            "id": "ONLYJOINS",
+            "name": "Nothing but join messages in here",
+            "is_channel": True,
+            "created": 1466025154,
+            "creator": "ABC123",
+            "name_normalized": "Nothing but join messages in here",
+            "last_read": "1503435939.000101",
+            "latest": {
+                "type": "message",
+                "subtype": "channel_join",
+                "ts": "1503353156.000247",
+                "user": "URVU20YHL",
+                "text": "<@URVU20YHL> has joined the channel",
+            },
+            "members": ["ABC123", "EFG123"],
+            "purpose": {
+                "value": "Watch people walk through the door",
+                "creator": "ABC123",
+                "last_set": 1503435128,
+            },
+        },
+    },
+}
+
+TEST_CHANNEL_HISTORY = {
+    "SOMEJOINS": {
+        "ok": True,
+        "messages": [
+            {
+                "type": "message",
+                "subtype": "channel_join",
+                "ts": "1503353156.000247",
+                "user": "URW2VDFK6",
+                "text": "<@URW2VDFK6> has joined the channel",
+                "inviter": "URVU20YHL",
+            },
+            {
+                "client_msg_id": "4858ae10-a803-4e01-80ff-28eb23776a60",
+                "type": "message",
+                "text": "test",
+                "user": "URVU20YHL",
+                "ts": "1503353087.000247",
+                "team": "TRTMY06HW",
+                "blocks": [
+                    {
+                        "type": "rich_text",
+                        "block_id": "gqY",
+                        "elements": [
+                            {
+                                "type": "rich_text_section",
+                                "elements": [{"type": "text", "text": "test"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+        "has_more": False,
+        "channel_actions_ts": None,
+        "channel_actions_count": 0,
+    },
+    "ONLYJOINS": {
+        "ok": True,
+        "messages": [
+            {
+                "type": "message",
+                "subtype": "channel_join",
+                "ts": "1503353156.000247",
+                "user": "URW2VDFK6",
+                "text": "<@URW2VDFK6> has joined the channel",
+                "inviter": "URVU20YHL",
+            },
+            {
+                "type": "message",
+                "subtype": "channel_join",
+                "ts": "1503353087.000247",
+                "user": "URVU20YHL",
+                "text": "<@URVU20YHL> has joined the channel",
+            },
+        ],
+        "has_more": False,
+        "channel_actions_ts": None,
+        "channel_actions_count": 0,
+    },
 }

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -18,11 +18,11 @@ from bot.slack import (
 
 # Database mocks
 import commands.topchannels
-from commands.topchannels import Channel, calc_channel_score
+from commands.topchannels import Channel, calc_channel_score, seconds_since_last_post
 from commands.welcome import welcome_user
 from bot.settings import SLACK_CLIENT, KARMABOT_ID
 from slackclient import SlackClient as RealSlackClient
-from tests.slack_testdata import TEST_USERINFO, TEST_CHANNEL_INFO
+from tests.slack_testdata import TEST_USERINFO, TEST_CHANNEL_INFO, TEST_CHANNEL_HISTORY
 
 FAKE_NOW = datetime(2017, 8, 23)
 
@@ -150,6 +150,10 @@ def mock_slack_api_call(monkeypatch):
         if call_type == "channels.info":
             channel_id = kwargs.get("channel")
             return TEST_CHANNEL_INFO[channel_id]
+
+        if call_type == "channels.history":
+            channel_id = kwargs.get("channel")
+            return TEST_CHANNEL_HISTORY[channel_id]
 
         if call_type == "chat.postMessage":
             return None
@@ -322,20 +326,28 @@ def test_get_available_username(mock_slack_api_call, test_user_id, expected):
     assert get_available_username(user_info) == expected
 
 
-def test_channel_score(mock_slack_api_call, frozen_now):
-    def _channel_score(channel):
-        channel_info = channel["channel"]
-        return calc_channel_score(
-            Channel(
-                channel_info["id"],
-                channel_info["name"],
-                channel_info["purpose"]["value"],
-                len(channel_info["members"]),
-                float(channel_info["latest"]["ts"]),
-                channel_info["latest"].get("subtype"),
-            )
+def _channel_score(channel):
+    channel_info = channel["channel"]
+    return calc_channel_score(
+        Channel(
+            channel_info["id"],
+            channel_info["name"],
+            channel_info["purpose"]["value"],
+            len(channel_info["members"]),
+            float(channel_info["latest"]["ts"]),
+            channel_info["latest"].get("subtype"),
         )
+    )
 
+
+def test_channel_score(mock_slack_api_call, frozen_now):
     most_recent = SLACK_CLIENT.api_call("channels.info", channel="CHANNEL42")
     less_recent = SLACK_CLIENT.api_call("channels.info", channel="CHANNEL43")
     assert _channel_score(most_recent) > _channel_score(less_recent)
+
+
+def test_ignore_message_subtypes(mock_slack_api_call, frozen_now):
+    latest_ignored = SLACK_CLIENT.api_call("channels.info", channel="SOMEJOINS")
+    all_ignored = SLACK_CLIENT.api_call("channels.info", channel="ONLYJOINS")
+    assert _channel_score(latest_ignored) > 0
+    assert _channel_score(all_ignored) == 0

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -332,6 +332,7 @@ def test_channel_score(mock_slack_api_call, frozen_now):
                 channel_info["purpose"]["value"],
                 len(channel_info["members"]),
                 float(channel_info["latest"]["ts"]),
+                channel_info["latest"].get("subtype"),
             )
         )
 


### PR DESCRIPTION
Allow karmabot to ignore certain message subtypes for the purposes of `topchannels` reporting. If the latest message in a channel is of an ignored subtype (initially only `channel_join`), look through channel history for the last message that would not be ignored. Channels with _only_ ignored messages are excluded from topchannels reports.

The logic of this seems to be finished, but I need to flesh out the mocks and tests. Putting it up for eyeball reviews and comments in the meantime.