### PR TITLE
Humanize topchannels times

### DIFF
--- a/commands/topchannels.py
+++ b/commands/topchannels.py
@@ -11,17 +11,7 @@ from slackclient import SlackClient
 
 from bot.settings import SLACK_CLIENT
 
-TOP_CHANNELS = """Glad you asked, here are some channels our Communtiy recommends:
-- #100daysofcode: share your 100 days journey and/or feedback on our course
-- #books: get notified about Packt's daily free ebook and/or share interesting books you are reading
-- #codechallenges: stuck? Ask your Python coding questions here, we learn more together!
-- #instagram: submit inspiring Python/coding/developer pictures for PyBites Instagram
-- #meetups / #pycon: the PyBites community is growing so maybe you can meet fellow Pythonistas in person!
-- #pybites-news: share interesting Python news/articles here helping us with our weekly Twitter news digest
-- #checkins: share your pythonic adventures with the community and help everyone grow!
-"""
-
-MSG_BEGIN = "Glad you asked, here are some channels our Communtiy recommends (based on member count and activity):\n"
+MSG_BEGIN = "Glad you asked, here are some channels our Community recommends (based on member count and activity):\n"
 MSG_LINE = (
     "- #{channel} ({member_count} members, last post {time_since_last_post}): {purpose}"
 )

--- a/commands/topchannels.py
+++ b/commands/topchannels.py
@@ -6,6 +6,7 @@ from math import exp
 from operator import itemgetter
 from typing import Dict, List, Optional
 
+import humanize
 from slackclient import SlackClient
 
 from bot.settings import SLACK_CLIENT
@@ -21,7 +22,9 @@ TOP_CHANNELS = """Glad you asked, here are some channels our Communtiy recommend
 """
 
 MSG_BEGIN = "Glad you asked, here are some channels our Communtiy recommends (based on member count and activity):\n"
-MSG_LINE = "- #{channel} ({member_count} members, {hours_since_last_post:.0f} hour(s) since last post): {purpose}"
+MSG_LINE = (
+    "- #{channel} ({member_count} members, last post {time_since_last_post}): {purpose}"
+)
 DEFAULT_NR_CHANNELS = 7
 
 Channel = namedtuple("Channel", "id name purpose num_members latest_ts latest_subtype")
@@ -97,7 +100,9 @@ def get_recommended_channels(**kwargs):
             MSG_LINE.format(
                 channel=channel.name,
                 member_count=channel.num_members,
-                hours_since_last_post=seconds_since_last_post(channel) / 3600,
+                time_since_last_post=humanize.naturaltime(
+                    seconds_since_last_post(channel)
+                ),
                 purpose=channel.purpose
                 or "<Invest today and get an awesome description!>",
             )

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,6 +3,7 @@ attrs==19.3.0
 certifi==2019.9.11
 chardet==3.0.4
 feedparser==5.2.1
+humanize==0.5.1
 idna==2.8
 importlib-metadata==0.23
 more-itertools==7.2.0


### PR DESCRIPTION
Since the changes in #31, `topchannels` output is likely to show channels whose last activity was beyond a day ago. This will get unwieldy, so we can pretty up the output with [humanize](https://pypi.org/project/humanize/).

As a side change, I went to fix a pair of typos. I noticed that one was in the `TOP_CHANNELS` string which was defined but never used. It seems to be from a previous or sample implementation, safe to get rid of at this point?