### PR TITLE
Allow `topchannels` in private messages

### DIFF
--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -42,6 +42,7 @@ PRIVATE_BOT_COMMANDS = {
     "doc": doc_command,
     "help": create_commands_table,
     "karma": get_karma,
+    "topchannels": get_recommended_channels,
     "updateusername": update_username,
     "username": get_user_name,
     "joke": joke,


### PR DESCRIPTION
Sometimes I want to peek at the `topchannels` list privately, or recommend that newcomers do so. It's a useful command, but can be a bit spammy in public channels. A private option seems handy.