### PR TITLE
add error handling to env vars

### DIFF
--- a/src/karmabot/settings.py
+++ b/src/karmabot/settings.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from pathlib import Path
@@ -5,19 +6,39 @@ from pathlib import Path
 from dotenv import load_dotenv
 from slackclient import SlackClient
 
+
+def _get_env_var(env_var: str):
+    env_var_value = os.environ.get(env_var)
+
+    # explicit check for None as None is returned by environ.get for non existing keys
+    if env_var_value is None:
+        raise KeyError(
+            f"{env_var} was not found. Please check your .karmabot file as well as the README.md."
+        )
+
+    if not env_var_value:
+        raise ValueError(
+            f"{env_var} was found but seems empty. Please check your .karmabot file as well as the README.md."
+        )
+
+    return env_var_value
+
+
 dotenv_path = Path(".").resolve() / ".karmabot"
 if dotenv_path.exists():
+    logging.info("Loading environmental variables from .karmabot.")
     load_dotenv(dotenv_path)
 
 # Environment variables
-KARMABOT_ID = os.environ.get("KARMABOT_SLACK_USER")
-SLACK_TOKEN = os.environ.get("KARMABOT_SLACK_TOKEN")
-SLACK_INVITE_TOKEN = os.environ.get("KARMABOT_SLACK_INVITE_USER_TOKEN")
-DATABASE_URL = os.environ.get("KARMABOT_DATABASE_URL")
+KARMABOT_ID = _get_env_var("KARMABOT_SLACK_USER")
+SLACK_TOKEN = _get_env_var("KARMABOT_SLACK_TOKEN")
+SLACK_INVITE_TOKEN = _get_env_var("KARMABOT_SLACK_INVITE_USER_TOKEN")
+DATABASE_URL = _get_env_var("KARMABOT_DATABASE_URL")
 
 # Slack
-GENERAL_CHANNEL = os.environ.get("KARMABOT_GENERAL_CHANNEL")
-ADMINS = os.environ.get("KARMABOT_ADMINS").split(",")  # type: ignore
+GENERAL_CHANNEL = _get_env_var("KARMABOT_GENERAL_CHANNEL")
+ADMINS = _get_env_var("KARMABOT_ADMINS")
+ADMINS = ADMINS.split(",")  # type: ignore
 SLACK_ID_FORMAT = re.compile(r"^<@[^>]+>$")
 SLACK_CLIENT = SlackClient(SLACK_TOKEN)
 


### PR DESCRIPTION
I found it confusing that the env vars are not checked and lead to non obvious errors like failed data connection because of "NoneType" error. So I added a helper function to parse env vars and inform the user if the expected env var is missing or if it is found but empty. This improves error handling and helps the user understand where the env vars are needed and how to fix errors.

First small contribution. 