### PR TITLE
final version 1.0 with tests and all three commands

### DIFF
--- a/src/karmabot/commands/note.py
+++ b/src/karmabot/commands/note.py
@@ -1,0 +1,113 @@
+import datetime
+import re
+from typing import Callable, Dict, Union
+
+from karmabot.db import db_session
+from karmabot.db.karma_note import KarmaNote
+from karmabot.db.karma_user import KarmaUser
+
+NOTE_CMD_PATTERN = re.compile(r"note\s(\w+)\s?(.*)")
+NOTE_COMMANDS: Dict[str, Callable] = {
+    "add": lambda text_arg, user: _add_note(text_arg, user),
+    "del": lambda text_arg, user: _del_note(text_arg, user),
+    "list": lambda text_arg, user: _list_notes(text_arg, user),
+    "default": lambda text_arg, user: f"Sorry {user.username}, your note command was not recognized. You can use {', '.join(NOTE_COMMANDS.keys())}.",
+}
+
+
+def note(**kwargs) -> Union[None, str]:
+    """Allows the user to store and retrieve simple notes.
+
+    - Syntax for adding a note: @karmabot note add <">my note<"> (note message can be in quotes)
+    - Syntax for listing notes: @karmabot note list
+    - Syntax for removing a note: @karmabote note del 1
+    """
+
+    id_arg = str(kwargs.get("user_id"))
+    text_arg = str(kwargs.get("text"))
+    user_id = id_arg.strip("<>@")
+
+    # retrieve current user
+    user = db_session.create_session().query(KarmaUser).get(user_id)
+    note_cmd = _parse_note_cmd(text_arg)
+
+    note_cmd_fnc = NOTE_COMMANDS.get(note_cmd, NOTE_COMMANDS["default"])
+
+    return note_cmd_fnc(text_arg, user)
+
+
+def _add_note(text_arg: str, user: KarmaUser) -> str:
+    """ Adds a new note to the database for the given user """
+    note_msg = _parse_note_cmd_argument(text_arg)
+    if not note_msg:
+        return (
+            f"Sorry {user.username}, could not find a note in your message. "
+            f"Please make sure you have surrounded your note with double or single quotes."
+        )
+
+    note = KarmaNote(
+        user_id=user.user_id, timestamp=datetime.datetime.now(), note=note_msg
+    )
+
+    session = db_session.create_session()
+    session.add(note)
+    session.commit()
+
+    return f"Hey {user.username}, you've just stored a note."
+
+
+def _del_note(text_arg: str, user: KarmaUser) -> str:
+    """ Deletes the note with the given note id """
+    note_id = _parse_note_cmd_argument(text_arg)
+
+    if not note_id:
+        return f"Sorry {user.username}, it seems you did not provide a correct note id."
+
+    session = db_session.create_session()
+    row_count = session.query(KarmaNote).filter(KarmaNote.id == note_id).delete()
+    session.commit()  # otherwise, the deletion is not performed
+
+    if row_count:
+        return f"Hey {user.username}, your note was successfully deleted."
+
+    return f"Hey {user.username}, something went wrong, no record was deleted. Please ask an admin..."
+
+
+def _list_notes(text_arg: str, user: KarmaUser) -> str:
+    """ """
+    notes = (
+        db_session.create_session()
+        .query(KarmaNote)
+        .filter(KarmaNote.user_id == user.user_id)
+        .all()
+    )
+
+    if not notes:
+        return f"Sorry {user.username}, you don't have any notes so far! Just start adding notes via the 'note add' command."
+
+    msg = ""
+    for note in notes:
+        msg += f"{note.id}. note from {note.timestamp.strftime('%Y-%m-%d, %H:%M')}: {note.note}.\n"
+
+    return msg
+
+
+def _parse_note_cmd(text_arg: str) -> str:
+    note_cmd = ""
+
+    match = NOTE_CMD_PATTERN.search(text_arg)
+    if match:
+        note_cmd = match.group(1).strip()
+
+    return note_cmd
+
+
+def _parse_note_cmd_argument(text_arg: str) -> str:
+    """ Get note message from user input. """
+    note_cmd_argument = ""
+
+    match = NOTE_CMD_PATTERN.search(text_arg)
+    if match:
+        note_cmd_argument = match.group(2).strip("\"'")
+
+    return note_cmd_argument

--- a/src/karmabot/commands/note.py
+++ b/src/karmabot/commands/note.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Callable, Dict, Union
+from typing import Callable, Dict, Tuple, Union
 
 from karmabot.db import db_session
 from karmabot.db.karma_note import KarmaNote
@@ -96,7 +96,7 @@ def _command_not_found(text_arg: str, user: KarmaUser) -> str:
     )
 
 
-def _parse_note_cmd(text_arg: str) -> (str, str):
+def _parse_note_cmd(text_arg: str) -> Tuple[str, str]:
     note_cmd = ("", "")
 
     match = NOTE_CMD_PATTERN.search(text_arg)
@@ -115,7 +115,7 @@ def _get_notes_for_user(user: KarmaUser) -> list:
     )
 
 
-def _note_exists(msg: str, user:KarmaUser) -> bool:
+def _note_exists(msg: str, user: KarmaUser) -> bool:
     session = db_session.create_session()
     q = session.query(KarmaNote).filter_by(note=msg, user_id=user.user_id)
 

--- a/src/karmabot/db/__all_models.py
+++ b/src/karmabot/db/__all_models.py
@@ -1,4 +1,3 @@
 # Add all models here. Ensures loading all models
-import karmabot.db.karma_note  # noqa: F401
 import karmabot.db.karma_transaction  # noqa: F401
 import karmabot.db.karma_user  # noqa: F401

--- a/src/karmabot/db/__all_models.py
+++ b/src/karmabot/db/__all_models.py
@@ -1,3 +1,4 @@
 # Add all models here. Ensures loading all models
+import karmabot.db.karma_note  # noqa: F401
 import karmabot.db.karma_transaction  # noqa: F401
 import karmabot.db.karma_user  # noqa: F401

--- a/src/karmabot/db/karma_note.py
+++ b/src/karmabot/db/karma_note.py
@@ -24,3 +24,9 @@ class KarmaNote(SqlAlchemyBase):
             f"[KarmaNote] ID: {self.id} | {self.user_id} -> "
             f"{self.timestamp} | Note: {self.note}"
         )
+
+    def __str__(self):
+        return (
+            f"(ID: {self.id}) from {self.timestamp.strftime('%Y-%m-%d, %H:%M')}: "
+            f"{self.note}."
+        )

--- a/src/karmabot/db/karma_note.py
+++ b/src/karmabot/db/karma_note.py
@@ -1,0 +1,26 @@
+import datetime
+
+import sqlalchemy as sa
+
+from karmabot.db.modelbase import SqlAlchemyBase
+
+
+class KarmaNote(SqlAlchemyBase):
+    """ Models a simple note system in the DB """
+
+    __tablename__ = "karma_note"
+
+    id: int = sa.Column(
+        sa.BigInteger().with_variant(sa.Integer, "sqlite"),
+        primary_key=True,
+        autoincrement=True,
+    )
+    user_id = sa.Column(sa.String, sa.ForeignKey("karma_user.user_id"), nullable=False)
+    timestamp = sa.Column(sa.DateTime, default=datetime.datetime.now, nullable=False)
+    note = sa.Column(sa.String)
+
+    def __repr__(self):
+        return (
+            f"[KarmaNote] ID: {self.id} | {self.user_id} -> "
+            f"{self.timestamp} | Note: {self.note}"
+        )

--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -12,6 +12,7 @@ from karmabot.commands.doc import doc_command
 from karmabot.commands.feed import get_pybites_last_entries
 from karmabot.commands.help import create_commands_table
 from karmabot.commands.joke import joke
+from karmabot.commands.note import note
 from karmabot.commands.score import get_karma, top_karma
 from karmabot.commands.tip import get_random_tip
 from karmabot.commands.topchannels import get_recommended_channels
@@ -30,22 +31,24 @@ TEXT_FILTER_REPLIES = {
 AUTOMATED_COMMANDS = {"welcome": welcome_user}  # not manual
 ADMIN_BOT_COMMANDS = {"top_karma": top_karma}
 PUBLIC_BOT_COMMANDS = {
-    "age": pybites_age,
     "add": add_command,
+    "age": pybites_age,
     "help": create_commands_table,
+    "joke": joke,
+    "note:": note,
     "tip": get_random_tip,
     "topchannels": get_recommended_channels,
-    "joke": joke,
 }
 PRIVATE_BOT_COMMANDS = {
-    "feed": get_pybites_last_entries,
     "doc": doc_command,
+    "feed": get_pybites_last_entries,
     "help": create_commands_table,
+    "joke": joke,
     "karma": get_karma,
+    "note": note,
     "topchannels": get_recommended_channels,
     "updateusername": update_username,
     "username": get_user_name,
-    "joke": joke,
 }
 
 Message = namedtuple("Message", "user_id channel_id text")

--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -44,11 +44,11 @@ PRIVATE_BOT_COMMANDS = {
     "feed": get_pybites_last_entries,
     "help": create_commands_table,
     "joke": joke,
-    "karma": get_karma,
     "note": note,
+    "karma": get_karma,
     "topchannels": get_recommended_channels,
-    "updateusername": update_username,
     "username": get_user_name,
+    "updateusername": update_username,
 }
 
 Message = namedtuple("Message", "user_id channel_id text")

--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -12,7 +12,6 @@ from karmabot.commands.doc import doc_command
 from karmabot.commands.feed import get_pybites_last_entries
 from karmabot.commands.help import create_commands_table
 from karmabot.commands.joke import joke
-from karmabot.commands.note import note
 from karmabot.commands.score import get_karma, top_karma
 from karmabot.commands.tip import get_random_tip
 from karmabot.commands.topchannels import get_recommended_channels
@@ -31,24 +30,22 @@ TEXT_FILTER_REPLIES = {
 AUTOMATED_COMMANDS = {"welcome": welcome_user}  # not manual
 ADMIN_BOT_COMMANDS = {"top_karma": top_karma}
 PUBLIC_BOT_COMMANDS = {
-    "add": add_command,
     "age": pybites_age,
+    "add": add_command,
     "help": create_commands_table,
-    "joke": joke,
-    "note": note,
     "tip": get_random_tip,
     "topchannels": get_recommended_channels,
+    "joke": joke,
 }
 PRIVATE_BOT_COMMANDS = {
-    "doc": doc_command,
     "feed": get_pybites_last_entries,
+    "doc": doc_command,
     "help": create_commands_table,
-    "joke": joke,
     "karma": get_karma,
     "topchannels": get_recommended_channels,
     "updateusername": update_username,
     "username": get_user_name,
-    "note": note,
+    "joke": joke,
 }
 
 Message = namedtuple("Message", "user_id channel_id text")

--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -12,6 +12,7 @@ from karmabot.commands.doc import doc_command
 from karmabot.commands.feed import get_pybites_last_entries
 from karmabot.commands.help import create_commands_table
 from karmabot.commands.joke import joke
+from karmabot.commands.note import note
 from karmabot.commands.score import get_karma, top_karma
 from karmabot.commands.tip import get_random_tip
 from karmabot.commands.topchannels import get_recommended_channels
@@ -30,22 +31,24 @@ TEXT_FILTER_REPLIES = {
 AUTOMATED_COMMANDS = {"welcome": welcome_user}  # not manual
 ADMIN_BOT_COMMANDS = {"top_karma": top_karma}
 PUBLIC_BOT_COMMANDS = {
-    "age": pybites_age,
     "add": add_command,
+    "age": pybites_age,
     "help": create_commands_table,
+    "joke": joke,
+    "note": note,
     "tip": get_random_tip,
     "topchannels": get_recommended_channels,
-    "joke": joke,
 }
 PRIVATE_BOT_COMMANDS = {
-    "feed": get_pybites_last_entries,
     "doc": doc_command,
+    "feed": get_pybites_last_entries,
     "help": create_commands_table,
+    "joke": joke,
     "karma": get_karma,
     "topchannels": get_recommended_channels,
     "updateusername": update_username,
     "username": get_user_name,
-    "joke": joke,
+    "note": note,
 }
 
 Message = namedtuple("Message", "user_id channel_id text")

--- a/src/karmabot/slack.py
+++ b/src/karmabot/slack.py
@@ -35,7 +35,7 @@ PUBLIC_BOT_COMMANDS = {
     "age": pybites_age,
     "help": create_commands_table,
     "joke": joke,
-    "note:": note,
+    "note": note,
     "tip": get_random_tip,
     "topchannels": get_recommended_channels,
 }

--- a/tests/test_karmabot.py
+++ b/tests/test_karmabot.py
@@ -323,23 +323,6 @@ def test_karma_note_del_other_users_note(mock_filled_db_session):
         assert len(notes) == 2
 
 
-# Messages / Slack
-def test_get_cmd():
-    pass
-
-
-def test_perform_bot_cmd():
-    pass
-
-
-def test_parse_next_msg():
-    pass
-
-
-def test_create_help_msg():
-    pass
-
-
 @pytest.mark.parametrize(
     "test_text, expected", [("Cheers everybody", "To _cheers_ I say: :beers:")]
 )

--- a/tests/test_karmabot.py
+++ b/tests/test_karmabot.py
@@ -7,11 +7,13 @@ from slackclient import SlackClient as RealSlackClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+import karmabot.commands.note
 import karmabot.commands.topchannels
 from karmabot.commands.joke import _get_closest_category
 from karmabot.commands.topchannels import Channel, calc_channel_score
 from karmabot.commands.welcome import welcome_user
 from karmabot.db import db_session
+from karmabot.db.karma_note import KarmaNote
 from karmabot.db.karma_transaction import KarmaTransaction
 from karmabot.db.karma_user import KarmaUser
 from karmabot.karma import Karma, _parse_karma_change
@@ -47,9 +49,11 @@ def engine():
 def tables(engine):
     KarmaUser.metadata.create_all(engine)
     KarmaTransaction.metadata.create_all(engine)
+    KarmaNote.metadata.create_all(engine)
     yield
     KarmaUser.metadata.drop_all(engine)
     KarmaTransaction.metadata.drop_all(engine)
+    KarmaNote.metadata.drop_all(engine)
 
 
 @pytest.fixture
@@ -215,6 +219,66 @@ def test_create_karma_user(mock_empty_db_session, mock_slack_api_call):
 
     assert first.username == "pybob"
     assert second.username == "clamytoe"
+
+
+# KarmaNote
+def test_karma_note_add(mock_filled_db_session):
+    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 1
+
+    note = notes[0]
+
+    assert note.id == 1
+    assert note.user_id == "ABC123"
+    assert note.timestamp is not None
+    assert note.note == "my first note"
+
+    karmabot.commands.note.note(user_id="ABC123", text="note add 'my second note'")
+
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 2
+
+    note = notes[-1]
+
+    assert note.note == "my second note"
+
+
+def test_karma_note_list(mock_filled_db_session):
+    output = karmabot.commands.note.note(user_id="ABC123", text="note list")
+
+    assert isinstance(output, str)
+    assert output.startswith("Sorry")
+
+    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+
+    output = karmabot.commands.note.note(user_id="ABC123", text="note list")
+    note = db_session.create_session().query(KarmaNote).all()[0]
+
+    assert isinstance(output, str)
+    assert output.startswith(f"{note.id}. note")
+
+
+def test_karma_note_del(mock_filled_db_session):
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 0
+
+    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+
+    notes = db_session.create_session().query(KarmaNote).all()
+    note = notes[0]
+
+    assert len(notes) == 1
+
+    karmabot.commands.note.note(user_id="ABC123", text=f"note del {note.id}")
+
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 0
 
 
 # Messages / Slack

--- a/tests/test_karmabot.py
+++ b/tests/test_karmabot.py
@@ -7,7 +7,6 @@ from slackclient import SlackClient as RealSlackClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-import karmabot.commands.note
 import karmabot.commands.topchannels
 from karmabot.commands.joke import _get_closest_category
 from karmabot.commands.topchannels import Channel, calc_channel_score
@@ -49,11 +48,9 @@ def engine():
 def tables(engine):
     KarmaUser.metadata.create_all(engine)
     KarmaTransaction.metadata.create_all(engine)
-    KarmaNote.metadata.create_all(engine)
     yield
     KarmaUser.metadata.drop_all(engine)
     KarmaTransaction.metadata.drop_all(engine)
-    KarmaNote.metadata.drop_all(engine)
 
 
 @pytest.fixture
@@ -282,8 +279,12 @@ def test_karma_note_del(mock_filled_db_session):
 
 
 def test_karma_note_add_twice(mock_filled_db_session):
-    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
-    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    output = karmabot.commands.note.note(
+        user_id="ABC123", text="note add my first note"
+    )
+    output = karmabot.commands.note.note(
+        user_id="ABC123", text="note add my first note"
+    )
 
     notes = db_session.create_session().query(KarmaNote).all()
 
@@ -292,15 +293,21 @@ def test_karma_note_add_twice(mock_filled_db_session):
 
 
 def test_karma_note_del_other_users_note(mock_filled_db_session):
-    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
-    output = karmabot.commands.note.note(user_id="EFG123", text="note add my first note")
-    
+    output = karmabot.commands.note.note(
+        user_id="ABC123", text="note add my first note"
+    )
+    output = karmabot.commands.note.note(
+        user_id="EFG123", text="note add my first note"
+    )
+
     notes = db_session.create_session().query(KarmaNote).all()
 
     assert len(notes) == 2
 
     for note in notes:
-        output = karmabot.commands.note.note(user_id="XYZ123", text=f"note del {note.id}")
+        output = karmabot.commands.note.note(
+            user_id="XYZ123", text=f"note del {note.id}"
+        )
 
         assert output.startswith("Sorry")
         assert len(notes) == 2

--- a/tests/test_karmabot.py
+++ b/tests/test_karmabot.py
@@ -281,6 +281,31 @@ def test_karma_note_del(mock_filled_db_session):
     assert len(notes) == 0
 
 
+def test_karma_note_add_twice(mock_filled_db_session):
+    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 1
+    assert output.startswith("Sorry")
+
+
+def test_karma_note_del_other_users_note(mock_filled_db_session):
+    output = karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    output = karmabot.commands.note.note(user_id="EFG123", text="note add my first note")
+    
+    notes = db_session.create_session().query(KarmaNote).all()
+
+    assert len(notes) == 2
+
+    for note in notes:
+        output = karmabot.commands.note.note(user_id="XYZ123", text=f"note del {note.id}")
+
+        assert output.startswith("Sorry")
+        assert len(notes) == 2
+
+
 # Messages / Slack
 def test_get_cmd():
     pass

--- a/tests/test_karmabot.py
+++ b/tests/test_karmabot.py
@@ -220,7 +220,9 @@ def test_create_karma_user(mock_empty_db_session, mock_slack_api_call):
 
 # KarmaNote
 def test_karma_note_add(mock_filled_db_session):
-    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    karmabot.commands.note.note(
+        user_id="ABC123", channel="", text="note add my first note"
+    )
 
     notes = db_session.create_session().query(KarmaNote).all()
 
@@ -233,7 +235,9 @@ def test_karma_note_add(mock_filled_db_session):
     assert note.timestamp is not None
     assert note.note == "my first note"
 
-    karmabot.commands.note.note(user_id="ABC123", text="note add 'my second note'")
+    karmabot.commands.note.note(
+        user_id="ABC123", channel="", text="note add 'my second note'"
+    )
 
     notes = db_session.create_session().query(KarmaNote).all()
 
@@ -245,14 +249,16 @@ def test_karma_note_add(mock_filled_db_session):
 
 
 def test_karma_note_list(mock_filled_db_session):
-    output = karmabot.commands.note.note(user_id="ABC123", text="note list")
+    output = karmabot.commands.note.note(user_id="ABC123", channel="", text="note list")
 
     assert isinstance(output, str)
     assert output.startswith("Sorry")
 
-    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    karmabot.commands.note.note(
+        user_id="ABC123", channel="", text="note add my first note"
+    )
 
-    output = karmabot.commands.note.note(user_id="ABC123", text="note list")
+    output = karmabot.commands.note.note(user_id="ABC123", channel="", text="note list")
     note = db_session.create_session().query(KarmaNote).all()[0]
 
     assert isinstance(output, str)
@@ -264,14 +270,18 @@ def test_karma_note_del(mock_filled_db_session):
 
     assert len(notes) == 0
 
-    karmabot.commands.note.note(user_id="ABC123", text="note add my first note")
+    karmabot.commands.note.note(
+        user_id="ABC123", channel="", text="note add my first note"
+    )
 
     notes = db_session.create_session().query(KarmaNote).all()
     note = notes[0]
 
     assert len(notes) == 1
 
-    karmabot.commands.note.note(user_id="ABC123", text=f"note del {note.id}")
+    karmabot.commands.note.note(
+        user_id="ABC123", channel="", text=f"note del {note.id}"
+    )
 
     notes = db_session.create_session().query(KarmaNote).all()
 
@@ -280,10 +290,10 @@ def test_karma_note_del(mock_filled_db_session):
 
 def test_karma_note_add_twice(mock_filled_db_session):
     output = karmabot.commands.note.note(
-        user_id="ABC123", text="note add my first note"
+        user_id="ABC123", channel="", text="note add my first note"
     )
     output = karmabot.commands.note.note(
-        user_id="ABC123", text="note add my first note"
+        user_id="ABC123", channel="", text="note add my first note"
     )
 
     notes = db_session.create_session().query(KarmaNote).all()
@@ -294,10 +304,10 @@ def test_karma_note_add_twice(mock_filled_db_session):
 
 def test_karma_note_del_other_users_note(mock_filled_db_session):
     output = karmabot.commands.note.note(
-        user_id="ABC123", text="note add my first note"
+        user_id="ABC123", channel="", text="note add my first note"
     )
     output = karmabot.commands.note.note(
-        user_id="EFG123", text="note add my first note"
+        user_id="EFG123", channel="", text="note add my first note"
     )
 
     notes = db_session.create_session().query(KarmaNote).all()
@@ -306,7 +316,7 @@ def test_karma_note_del_other_users_note(mock_filled_db_session):
 
     for note in notes:
         output = karmabot.commands.note.note(
-            user_id="XYZ123", text=f"note del {note.id}"
+            user_id="XYZ123", channel="", text=f"note del {note.id}"
         )
 
         assert output.startswith("Sorry")


### PR DESCRIPTION
I added a new private and public command `note` with three subcommands:
- `note add <message>` stores a new note in the database with id, user_id as fk, timestamp and note message
- `note list` lists all notes from the db for the current user in the format <id> note from <timestamp>: <message>, with linebreak between each note
- `note del <id>` deletes note with <id> from database.

Added some tests and tried to be as failsave as possible.

![Screenshot_2](https://user-images.githubusercontent.com/9614291/94070375-5e0c5180-fdf2-11ea-8753-1ab2f9e1ec3f.png)


