### PR TITLE
poetry and conda for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ You should follow the [instructions](https://github.com/python-poetry/poetry) to
 
 The poetry virtual environment should be available in the the project folder as `.venv` folder as specified in `poetry.toml`. This helps with `.venv` detection in IDEs.
 
+#### Conda users
+
+If you use the Anaconda Python distribution (strongly recommended for Windows users) and `conda create` for your virtual environments, then you will not be able to use the `.venv` environment created by poetry because it is not a conda environment. If you want to use `poetry` disable poetry's behavior of creating a new virtual environment with the following command: `poetry config virtualenvs.create false`. You can add `--local` if you don't want to change this setting globally but only for the current project. See the [poetry configuration docs](https://python-poetry.org/docs/configuration/) for more details.
+
+Now, when you run `poetry install`, poetry will install all dependencies to your conda environment. You can verify this by running `pip freeze` after `poetry install`.
+
 ### Testing and linting
 
 For testing you need to install [nox](https://nox.thea.codes/en/stable/) separately from the project venv created by poetry. For testing just use the `nox` command within the project folder. You can run all the nox sessions separately if need, e.g.,


### PR DESCRIPTION
I had a bit of a trouble getting poetry running under Windows. Installation is easy, but poetry install creates a new venv by default, which does not work well with conda, if you use Anaconda for Windows as your main Python distribution and conda as package manager and venv manager.

So I added a solution for users that want to work with conda and poetry.