### PR TITLE
option to provide defaults for env variables that are not set 

### DIFF
--- a/src/karmabot/settings.py
+++ b/src/karmabot/settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 
-def _get_env_var(env_var: str, default=None):
+def _get_env_var(env_var: str, default: str = None) -> str:
     env_var_value = os.environ.get(env_var)
 
     # explicit check for None as None is returned by environ.get for non existing keys

--- a/src/karmabot/settings.py
+++ b/src/karmabot/settings.py
@@ -6,11 +6,14 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 
-def _get_env_var(env_var: str):
+def _get_env_var(env_var: str, default=None):
     env_var_value = os.environ.get(env_var)
 
     # explicit check for None as None is returned by environ.get for non existing keys
     if env_var_value is None:
+        if default is not None:
+            return default
+
         raise KeyError(
             f"{env_var} was not found. Please check your .karmabot file as well as the README.md."
         )
@@ -33,7 +36,7 @@ KARMABOT_ID = _get_env_var("KARMABOT_SLACK_USER")
 DATABASE_URL = _get_env_var("KARMABOT_DATABASE_URL")
 SLACK_APP_TOKEN = _get_env_var("KARMABOT_SLACK_APP_TOKEN")
 SLACK_BOT_TOKEN = _get_env_var("KARMABOT_SLACK_BOT_TOKEN")
-TEST_MODE = bool(_get_env_var("KARMABOT_TEST_MODE") == "true")
+TEST_MODE = _get_env_var("KARMABOT_TEST_MODE", default="false") == "true"
 logging.info("Test mode enabled: %s", TEST_MODE)
 
 # Slack

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,29 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from karmabot.settings import _get_env_var
+
+
+@pytest.mark.parametrize("env_var", ["true", "false"])
+def test_get_env_var(env_var):
+    with patch.dict(os.environ, {"KARMABOT_TEST_MODE": env_var}):
+        assert _get_env_var("KARMABOT_TEST_MODE") == env_var
+
+
+def test_exception_env_variable_not_found():
+    with patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(KeyError):
+            _get_env_var("KARMABOT_TEST_MODE")
+
+
+def test_exception_env_variable_empty():
+    with patch.dict(os.environ, {"KARMABOT_TEST_MODE": ""}):
+        with pytest.raises(ValueError):
+            _get_env_var("KARMABOT_TEST_MODE")
+
+
+def test_return_default_value_if_env_variable_not_set():
+    with patch.dict(os.environ, {}, clear=True):
+        assert _get_env_var("KARMABOT_TEST_MODE", default="false") == "false"


### PR DESCRIPTION
I was going to go with try/except around `TEST_MODE`, but adding a new optional argument to `_get_env_var` we can use this for other use cases too.

Issue: https://github.com/PyBites-Open-Source/karmabot/issues/84