### PR TITLE
add release actions

### DIFF
--- a/.github/workflows/pre_release.yml
+++ b/.github/workflows/pre_release.yml
@@ -1,0 +1,22 @@
+name: Publish to Test PyPI
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  test_pypi_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install Poetry
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+      - name: Add Poetry to path
+        run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+      - run: poetry install
+      - run: poetry run pytest
+      - run: poetry config repositories.testpypi https://test.pypi.org/legacy/
+      - run: poetry config pypi-token.testpypi ${{ secrets.TEST_PYPI_API_TOKEN }}
+      - name: Publish package
+        run: poetry publish --build -r testpypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Publish to PyPI
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi_release:
+    name: Builds Using Poetry and Publishes to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Install Poetry
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+      - name: Add Poetry to path
+        run: echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+      - run: poetry install
+      - run: poetry run pytest
+      - run: poetry config pypi-token.pypi "${{ secrets.PYPI_API_TOKEN }}"
+      - name: Publish package
+        run: poetry publish --build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "karmabot"
-version = "1.4"
+version = "2.0"
 description = "PyBites Karmabot - A Python based Slack Chatbot for Community interaction"
 homepage = "https://github.com/PyBites-Open-Source/karmabot"
 keywords = ["karmabot"]


### PR DESCRIPTION
As per https://www.ianwootten.co.uk/2020/10/23/publishing-to-pypi-using-github-actions/

Tried it out on a stub repo and it worked: https://github.com/bbelderbos/poetry-ghactions

So by default it pushed to test PyPI upon tag and to the live PyPI upon making a release.

I already set the secrets on our repo.